### PR TITLE
INTL-591 fix unit source corruption

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -874,11 +874,13 @@ def submit(request, unit):
     if form.is_valid():
         if form.updated_fields:
             for field, old_value, new_value in form.updated_fields:
+                # (jgonzale|2014-09-05|INTL-591): skip unsolicited modification to the source field.
                 if field == SubmissionFields.SOURCE:
                     logging.warning(
-                        u'Corrupted submission for unit_id {0} - ' \
-                        u'field_values - (old_value, {1}), (new_value, {2}) - ' \
-                        u'request info - {3}'.format(unit.id, old_value, new_value, repr(request))
+                        u'Corrupted submission for (unit_id, {0}) - ' \
+                        u'(submitter, {1}) ' \
+                        u'(source_old_value, {2}) ' \
+                        u'(request info - {3})'.format(unit.id, request.profile, old_value, repr(request))
                     )
                     continue
                 sub = Submission(

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -874,6 +874,13 @@ def submit(request, unit):
     if form.is_valid():
         if form.updated_fields:
             for field, old_value, new_value in form.updated_fields:
+                if field == SubmissionFields.SOURCE:
+                    logging.warning(
+                        u'Corrupted submission for unit_id {0} - ' \
+                        u'field_values - (old_value, {1}), (new_value, {2}) - ' \
+                        u'request info - {3}'.format(unit.id, old_value, new_value, repr(request))
+                    )
+                    continue
                 sub = Submission(
                         creation_time=current_time,
                         translation_project=translation_project,


### PR DESCRIPTION
The proposed patch consists in adding some logic to the servlet that handles submission of translations so it would skip|ignore updates submission request for source field attributes (coming from the webapp). It looks pretty straight forward.

Testing Done:
- I was able to interactive test the fix in my playground and is looking good, no side effects.
- I tried to write some unit test for this change but I wasn't able to get the test suite to run, following the instructions in http://docs.translatehouse.org/projects/pootle/en/stable-2.5.0/developers/testing.html It seems to failed when trying to create the sandbox DB for testing https://gist.github.com/jagg81/31468fe3bd0d69262ff5
