### PR TITLE
Remove source_f attribute from UnitForm class. Ref #INTL-1512

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -32,7 +32,7 @@ from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 from pootle_store.models import Unit
 from pootle_store.util import UNTRANSLATED, FUZZY, TRANSLATED
-from pootle_store.fields import PLURAL_PLACEHOLDER, to_db
+from pootle_store.fields import to_db
 
 ############## text cleanup and highlighting #########################
 
@@ -205,11 +205,9 @@ def unit_form_factory(language, snplurals=None, request=None):
         class Meta:
             model = Unit
             exclude = ['store', 'developer_comment', 'translator_comment',
-                       'submitted_by', 'commented_by']
+                       'submitted_by', 'commented_by', 'source_f']
 
         id = forms.IntegerField(required=False)
-        source_f = MultiStringFormField(nplurals=snplurals or 1,
-                                        required=False, textarea=False)
         target_f = MultiStringFormField(nplurals=tnplurals, required=False,
                                         attrs=target_attrs)
         state = UnitStateField(required=False, label=_('Needs work'),
@@ -220,20 +218,6 @@ def unit_form_factory(language, snplurals=None, request=None):
         def __init__(self, *args, **argv):
             super(UnitForm, self).__init__(*args, **argv)
             self.updated_fields = []
-
-        def clean_source_f(self):
-            value = self.cleaned_data['source_f']
-
-            if self.instance.source.strings != value:
-                self.instance._source_updated = True
-                self.updated_fields.append((SubmissionFields.SOURCE,
-                                            to_db(self.instance.source),
-                                            to_db(value)))
-            if snplurals == 1:
-                # plural with single form, insert placeholder
-                value.append(PLURAL_PLACEHOLDER)
-
-            return value
 
         def clean_target_f(self):
             value = self.cleaned_data['target_f']

--- a/pootle/apps/pootle_store/templates/unit/edit.html
+++ b/pootle/apps/pootle_store/templates/unit/edit.html
@@ -84,7 +84,6 @@
         <form action="" method="post" name="translate" id="translate">
           {{ form.id.as_hidden }}
           {{ form.index.as_hidden }}
-          {{ form.source_f.as_hidden }}
           <div class="sources">
             <!-- Alternative source language translations -->
             {% for altunit in altsrcs %}

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -874,7 +874,7 @@ def submit(request, unit):
     if form.is_valid():
         if form.updated_fields:
             for field, old_value, new_value in form.updated_fields:
-                # (jgonzale|2014-09-05|INTL-591): skip unsolicited modification to the source field.
+                # (jgonzale|2014-09-05|INTL-591): log unsolicited modification to the source field.
                 if field == SubmissionFields.SOURCE:
                     logging.warning(
                         u'Corrupted submission for (unit_id, {0}) - ' \
@@ -882,7 +882,6 @@ def submit(request, unit):
                         u'(source_old_value, {2}) ' \
                         u'(request info - {3})'.format(unit.id, request.profile, old_value, repr(request))
                     )
-                    continue
                 sub = Submission(
                         creation_time=current_time,
                         translation_project=translation_project,


### PR DESCRIPTION
Removing the source_f attribute from the UnitForm(...) class should prevent the webapp from overriding the value. This is a bug that causes corruption of translation unit data submitted thru the web app.

The unit_form_factory() method is only used when submitting translations thru the webapp, which makes it a reasonable safe change.
