### PR TITLE
Fixed source_f crash when looking for untranslated words (remaining source_f cleanup). Ref #INTL-1567

### DIFF
--- a/pootle/apps/pootle_store/forms.py
+++ b/pootle/apps/pootle_store/forms.py
@@ -222,15 +222,12 @@ def unit_form_factory(language, snplurals=None, request=None):
             self.updated_fields = []
 
         def clean_source_f(self):
-            value = self.cleaned_data['source_f']
+            # NOTE(jgonzale|2014-09-05|INTL-591): treat it as readonly attribute field, it should not be modified
+            value = self.instance.source.strings
 
-            if self.instance.source.strings != value:
-                self.instance._source_updated = True
-                self.updated_fields.append((SubmissionFields.SOURCE,
-                                            to_db(self.instance.source),
-                                            to_db(value)))
             if snplurals == 1:
                 # plural with single form, insert placeholder
+                value = list(value)
                 value.append(PLURAL_PLACEHOLDER)
 
             return value

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -874,7 +874,7 @@ def submit(request, unit):
     if form.is_valid():
         if form.updated_fields:
             for field, old_value, new_value in form.updated_fields:
-                # (jgonzale|2014-09-05|INTL-591): skip unsolicited modification to the source field.
+                # (jgonzale|2014-09-05|INTL-591): log unsolicited modification to the source field
                 if field == SubmissionFields.SOURCE:
                     logging.warning(
                         u'Corrupted submission for (unit_id, {0}) - ' \
@@ -882,7 +882,6 @@ def submit(request, unit):
                         u'(source_old_value, {2}) ' \
                         u'(request info - {3})'.format(unit.id, request.profile, old_value, repr(request))
                     )
-                    continue
                 sub = Submission(
                         creation_time=current_time,
                         translation_project=translation_project,


### PR DESCRIPTION
The work done in https://github.com/Yelp/pootle/pull/3 excluded the source_f attribute from both UnitForm model and edit unit template. This changed though fixed the source_f corruption issue, it also introduced a bug that caused the /translate.html view to crash resulting in an infinite loader.

Things I did here:
- Reintroduced https://github.com/Yelp/pootle/pull/3 (which was reverted when when "remaining words" bug was found)
- Search the entire source code for uses of source_f attribute. This time with special emphasis on non python code e.g. javascript modules, which is something we missed in https://github.com/Yelp/pootle/pull/3
- Change the editor.js module to verify the html element `id_source_f` exists before attempting to access its attributes.
- Augmented the interactive testing and manual verification to cover those use cases we missed, since sadly, we don't have a working test suite for version 2.5.0.
