### PR TITLE
Return http 400 response on corrupted translation requests

### DIFF
--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -855,7 +855,10 @@ def submit(request, unit):
 
     # (jgonzale|2014-12-04|INTL-1824): check for corrupted translation requests
     if unit.id != int(request.POST['id']):
-        logging.warning(u'submission aborted (request info - {0})'.format(repr(request)))
+        logging.warning(
+            u'submission aborted (request info -\
+            REQUEST_URI {0},\
+            POST unit id {1})'.format(request.META['REQUEST_URI'], request.POST['id']))
         return HttpResponseBadRequest('There seems to be something wrong with this request. Please try again later.')
 
     translation_project = request.translation_project


### PR DESCRIPTION
When a translation is corrupted both the `source_f` and the `target_f` attributes are overridden.

As part of the work done in https://github.com/Yelp/pootle/pull/4 to stop the corruption of translations submitted via the Pootle webapp, we successfully stop the translation unit `source_f` attribute from being overridden. However, this seems to only fix part of the problem since the target_f could also be corrupted.

This change prevents the translation request from being processed in the servlet (don't save the translation), if it is a request is for translating a corrupted string. Probably returning a http 400 sounds like a good idea in this case. The user could then try again later. 

The check is pretty trivial, the id of translation unit instance should match the id of the translation included in the http POST data.

I validated this interactively in my playground.
