### PR TITLE
alter tables that create unique keys that are too long to have row_format DYNAMIC

### DIFF
--- a/pootle/apps/pootle_app/migrations/0015_auto__add_unique_directory_pootle_path.py
+++ b/pootle/apps/pootle_app/migrations/0015_auto__add_unique_directory_pootle_path.py
@@ -12,10 +12,13 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Adding unique constraint on 'Directory', fields ['pootle_path']
+        # Set table row format to DYNAMIC to change unique key length constraint from 767 bytes to 3072
+        db.execute("ALTER TABLE `pootle_app_directory` ROW_FORMAT=DYNAMIC")
         db.create_unique(u'pootle_app_directory', ['pootle_path'])
 
     def backwards(self, orm):
         # Removing unique constraint on 'Directory', fields ['pootle_path']
+        db.execute("ALTER TABLE `pootle_app_directory` ROW_FORMAT=COMPACT")
         db.delete_unique(u'pootle_app_directory', ['pootle_path'])
 
 

--- a/pootle/apps/pootle_project/migrations/0001_initial.py
+++ b/pootle/apps/pootle_project/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(SchemaMigration):
         # Adding model 'Project'
         db.create_table('pootle_app_project', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('code', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255, db_index=True)),
+            ('code', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
             ('fullname', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('description', self.gf('django.db.models.fields.TextField')(blank=True)),
             ('description_html', self.gf('django.db.models.fields.TextField')(blank=True)),
@@ -27,6 +27,8 @@ class Migration(SchemaMigration):
             ('report_target', self.gf('django.db.models.fields.CharField')(max_length=512, blank=True)),
         ))
         db.send_create_signal('pootle_project', ['Project'])
+        db.execute("ALTER TABLE `pootle_app_project` ROW_FORMAT=DYNAMIC")
+        db.create_unique(u'pootle_app_project', ['code'])
 
 
     def backwards(self, orm):

--- a/pootle/apps/pootle_store/migrations/0001_initial.py
+++ b/pootle/apps/pootle_store/migrations/0001_initial.py
@@ -73,12 +73,14 @@ class Migration(SchemaMigration):
             ('pending', self.gf('pootle_store.fields.TranslationStoreField')(ignore='.pending', max_length=255)),
             ('tm', self.gf('pootle_store.fields.TranslationStoreField')(ignore='.tm', max_length=255)),
             ('parent', self.gf('django.db.models.fields.related.ForeignKey')(related_name='child_stores', to=orm['pootle_app.Directory'])),
-            ('pootle_path', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255, db_index=True)),
+            ('pootle_path', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
             ('name', self.gf('django.db.models.fields.CharField')(max_length=128)),
             ('sync_time', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime(1, 1, 1, 0, 0))),
             ('state', self.gf('django.db.models.fields.IntegerField')(default=0, db_index=True)),
         ))
         db.send_create_signal('pootle_store', ['Store'])
+        db.execute("ALTER TABLE `pootle_store_store` ROW_FORMAT=DYNAMIC")
+        db.create_unique(u'pootle_store_store', ['pootle_path'])
 
         # Adding unique constraint on 'Store', fields ['parent', 'name']
         db.create_unique('pootle_store_store', ['parent_id', 'name'])

--- a/pootle/apps/pootle_translationproject/migrations/0001_initial.py
+++ b/pootle/apps/pootle_translationproject/migrations/0001_initial.py
@@ -14,9 +14,11 @@ class Migration(SchemaMigration):
             ('description', self.gf('django.db.models.fields.TextField')(blank=True)),
             ('description_html', self.gf('django.db.models.fields.TextField')(blank=True)),
             ('real_path', self.gf('django.db.models.fields.FilePathField')(max_length=100)),
-            ('pootle_path', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255, db_index=True)),
+            ('pootle_path', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
         ))
         db.send_create_signal('pootle_translationproject', ['TranslationProject'])
+        db.execute("ALTER TABLE `pootle_app_translationproject` ROW_FORMAT=DYNAMIC")
+        db.create_unique(u'pootle_app_translationproject', ['pootle_path'])
 
     def backwards(self, orm):
         # Removing unique constraint on 'TranslationProject', fields ['language', 'project']

--- a/pootle/apps/virtualfolder/migrations/0001_initial.py
+++ b/pootle/apps/virtualfolder/migrations/0001_initial.py
@@ -19,6 +19,7 @@ class Migration(SchemaMigration):
             ('description', self.gf('pootle.core.markup.fields.MarkupField')(blank=True)),
         ))
         db.send_create_signal(u'virtualfolder', ['VirtualFolder'])
+        db.execute("ALTER TABLE `virtualfolder_virtualfolder` ROW_FORMAT=DYNAMIC")
 
         # Adding unique constraint on 'VirtualFolder', fields ['name', 'location']
         db.create_unique(u'virtualfolder_virtualfolder', ['name', 'location'])

--- a/pootle/apps/virtualfolder/migrations/0002_auto__add_virtualfoldertreeitem__add_unique_virtualfoldertreeitem_dire.py
+++ b/pootle/apps/virtualfolder/migrations/0002_auto__add_virtualfoldertreeitem__add_unique_virtualfoldertreeitem_dire.py
@@ -14,9 +14,11 @@ class Migration(SchemaMigration):
             ('directory', self.gf('django.db.models.fields.related.ForeignKey')(related_name='vf_treeitems', to=orm['pootle_app.Directory'])),
             ('vfolder', self.gf('django.db.models.fields.related.ForeignKey')(related_name='vf_treeitems', to=orm['virtualfolder.VirtualFolder'])),
             ('parent', self.gf('django.db.models.fields.related.ForeignKey')(related_name='child_vf_treeitems', null=True, to=orm['virtualfolder.VirtualFolderTreeItem'])),
-            ('pootle_path', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255, db_index=True)),
+            ('pootle_path', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
         ))
         db.send_create_signal(u'virtualfolder', ['VirtualFolderTreeItem'])
+        db.execute("ALTER TABLE `virtualfolder_virtualfolder` ROW_FORMAT=DYNAMIC")
+        db.create_unique(u'virtualfolder_virtualfoldertreeitem', ['pootle_path'])
 
         # Adding M2M table for field stores on 'VirtualFolderTreeItem'
         m2m_table_name = db.shorten_name(u'virtualfolder_virtualfoldertreeitem_stores')


### PR DESCRIPTION
@ENuge I found all of the tables that were creating unique keys that violated the max length of 767 bytes and altered the tables to have row_format=DYNAMIC. This, in addition to have innodb_file_format=barracuda and innodb_large_prefix=true in our mysql configs should change the restriction to be 3072 bytes, and thus we can run these migrations without errors.
