### PR TITLE
fix virtualfoldertreeitem migration

### DIFF
--- a/pootle/__version__.py
+++ b/pootle/__version__.py
@@ -22,5 +22,5 @@
 
 
 build = 26100
-sver = "2.6.1-yelp1"
+sver = "2.6.1-yelp2"
 ver = (2, 6, 1)

--- a/pootle/apps/virtualfolder/migrations/0002_auto__add_virtualfoldertreeitem__add_unique_virtualfoldertreeitem_dire.py
+++ b/pootle/apps/virtualfolder/migrations/0002_auto__add_virtualfoldertreeitem__add_unique_virtualfoldertreeitem_dire.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
             ('pootle_path', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
         ))
         db.send_create_signal(u'virtualfolder', ['VirtualFolderTreeItem'])
-        db.execute("ALTER TABLE `virtualfolder_virtualfolder` ROW_FORMAT=DYNAMIC")
+        db.execute("ALTER TABLE `virtualfolder_virtualfoldertreeitem` ROW_FORMAT=DYNAMIC")
         db.create_unique(u'virtualfolder_virtualfoldertreeitem', ['pootle_path'])
 
         # Adding M2M table for field stores on 'VirtualFolderTreeItem'


### PR DESCRIPTION
@ENuge @felfilali the alter table was for the wrong table =(
it should've altered `virtualfolder_virtualfoldertreeitem`
