### PR TITLE
bump 2.7.2-yelp1 to 2.7.2-yelp2

### DIFF
--- a/pootle/__init__.py
+++ b/pootle/__init__.py
@@ -9,6 +9,6 @@
 
 from pootle.core.utils.version import get_version
 
-VERSION = (2, 7, 2, 'yelp', 1)
+VERSION = (2, 7, 2, 'yelp', 2)
 
 __version__ = get_version(VERSION)


### PR DESCRIPTION
@ENuge I bumped the version on pypi to fix the uploaded wheels, so we should bump this as well.
Note this merges to stable/2.7.2
