### PR TITLE
bump 2.6.1-yelp2 to 2.6.1-yelp3

### DIFF
--- a/pootle/__version__.py
+++ b/pootle/__version__.py
@@ -22,5 +22,5 @@
 
 
 build = 26100
-sver = "2.6.1-yelp2"
+sver = "2.6.1-yelp3"
 ver = (2, 6, 1)


### PR DESCRIPTION
@ENuge I bumped the version on pypi to fix the uploaded wheels, so we should bump this as well.
