### PR TITLE
Add packages to build-depends in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: python-pootle
 Section: python
 Priority: optional
 Maintainer: Yelp i18n <i18n+pootle@yelp.com>
-Build-Depends: debhelper (>= 7), python (>= 2.7), dh-virtualenv (>= 0.8)
+Build-Depends: debhelper (>= 7), python2.7, dh-virtualenv, python-lxml, python-pip, python-setuptools
 Standards-Version: 3.9.5
 
 Package: python-pootle
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.1), python2.7, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}
+Pre-Depends: dpkg (>= 1.16.1)
+Depends: ${misc:Depends}
 Description: Pootle is an online translation and localization tool.
  It works to lower the barrier of entry, providing tools to enable teams to work towards higher quality while welcoming newcomers.

--- a/debian/python-pootle.substvars
+++ b/debian/python-pootle.substvars
@@ -1,1 +1,1 @@
-misc:Depends=
+misc:Depends= 

--- a/pootle/__init__.py
+++ b/pootle/__init__.py
@@ -9,6 +9,6 @@
 
 from pootle.core.utils.version import get_version
 
-VERSION = (2, 7, 2, 'yelp', 3)
+VERSION = (2, 7, 2, 'yelp', 4)
 
 __version__ = get_version(VERSION)


### PR DESCRIPTION
@ENuge @felfilali This change is so that [mk-build-deps](http://manpages.ubuntu.com/manpages/trusty/man1/mk-build-deps.1.html) can create a package with build deps. This lets dpkg-buildpackage to build the Pootle package with all the build dependencies already installed. We also can add all our build dependencies in one place (debian/control)
