### PR TITLE
Stats: wrap jobs with close_if_unusable_or_obsolete() for rq workers

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-pootle (2.7.2-yelp6) lucid; urgency=low
+
+  * Stats: wrap jobs with close_if_unusable_or_obsolete() for rq workers
+
+ -- Desmond Chan <deschan@yelp.com>  Thurs, 03 May 2016 11:45:00 -0700
+
 python-pootle (2.7.2-yelp5) lucid; urgency=low
 
   * Fix quality checks

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -681,7 +681,14 @@ def update_cache_job(instance):
     job = get_current_job()
     job_wrapper = JobWrapper(job.id, job.connection)
     keys, decrement = job_wrapper.get_job_params()
+
+    # close unusable and obsolete connections before and after the job
+    # Note: setting CONN_MAX_AGE parameter can have negative side-effects
+    # CONN_MAX_AGE value should be lower than DB wait_timeout
+    connection.close_if_unusable_or_obsolete()
     instance._update_cache_job(keys, decrement)
+    connection.close_if_unusable_or_obsolete()
+
     job_wrapper.clear_job_params()
 
 


### PR DESCRIPTION
@ENuge @felfilali this is applying https://github.com/ta2-1/pootle/commit/438d914349407e46c31deba05e9dbc7810e4d9f7

Our mysql server has `wait_timeout` set to 4 hours. Since the rq workers maintain an open connection to the mysql server, the connection gets closed after 4 hours of inactivity. This should close if the connection has reached `CONN_MAX_AGE` seconds.

Lastly, we're going to have to define CONN_MAX_AGE in our pootle settings, which should be lower than our `wait_timeout` value (See https://docs.djangoproject.com/en/1.7/ref/settings/#conn-max-age for more info)
